### PR TITLE
Tenant Id of the Session has wrong value

### DIFF
--- a/src/Abp.TestBase/TestBase/Runtime/Session/TestAbpSession.cs
+++ b/src/Abp.TestBase/TestBase/Runtime/Session/TestAbpSession.cs
@@ -15,7 +15,11 @@ namespace Abp.TestBase.Runtime.Session
             {
                 if (!_multiTenancy.IsEnabled)
                 {
-                    return 1;
+ 					if (_tenantId == null)
+					{
+					    return null;						
+					}
+                    else return 1;
                 }
                 
                 return _tenantId;


### PR DESCRIPTION
If multi tenancy is disabled, Tenant Id of the Session should be either 1 or null.